### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/File/Find/Duplicates.pm6
+++ b/lib/File/Find/Duplicates.pm6
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 use v6;
-module File::Find::Duplicates:auth<labster>;
+unit module File::Find::Duplicates:auth<labster>;
 
 use Digest;
 use File::Compare;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.