### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
   "name"        : "File::Find::Duplicates",
+  "license"     : "Artistic-2.0",
   "version"     : "*",
   "description" : "Get a list of duplicate files in directories",
   "provides"    : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license